### PR TITLE
Rename filter method.

### DIFF
--- a/lib/oojspec/engine.rb
+++ b/lib/oojspec/engine.rb
@@ -2,7 +2,7 @@ require "rails-sandbox-assets"
 
 module Oojspec
   class OojspecFilter
-    def self.filter(controller)
+    def self.before(controller)
       return unless controller.params[:path].try :start_with?, 'oojspec'
       controller.template = 'oojspec/runner'
       controller.iframe_template = 'oojspec/iframe'


### PR DESCRIPTION
I don't know when this changed:

"The filter class must implement a method with the same name as the filter, so for the before_action filter the class must implement a before method, and so on."

http://guides.rubyonrails.org/action_controller_overview.html
